### PR TITLE
html output style fix + error fix if more then 15 conditions without color specification is used

### DIFF
--- a/colorize.pl
+++ b/colorize.pl
@@ -36,6 +36,7 @@ my @searchstring ;
 my @colorcode ; 
 my @paintway ;
 my @colorpresets = ("u18", "u28", "u38", "u48", "u78", "l10", "l20", "l30", "l40", "l70", "l11", "l22", "l33", "l74", "l76") ;
+my @htmlcolorpresets = ("u18", "u28", "u68", "u48", "u58", "l10", "l20", "l30", "l40", "l70", "l01", "l02", "l03", "l04", "l06") ;
 my $i = 0;
 
 # main 
@@ -49,6 +50,7 @@ foreach $argsnum (0 .. $argscount) {
 	if ($ARGV[$argsnum] eq "--html") {
 		$htmlout = 1;
 		htmlheader();
+		@colorpresets = @htmlcolorpresets;
 	}
 }
 

--- a/colorize.pl
+++ b/colorize.pl
@@ -36,6 +36,7 @@ my @searchstring ;
 my @colorcode ; 
 my @paintway ;
 my @colorpresets = ("u18", "u28", "u38", "u48", "u78", "l10", "l20", "l30", "l40", "l70", "l11", "l22", "l33", "l74", "l76") ;
+my $i = 0;
 
 # main 
 #
@@ -55,8 +56,9 @@ foreach $argsnum (0 .. $argscount) {
 	if ($ARGV[$argsnum] ne "--html") {
 		my $tempstring = $ARGV[$argsnum] ; 
 		if ($ARGV[$argsnum] =~ /^[-|+]:/) {
+			if ($i == @colorpresets) {$i=0;}
 			($paintway[$argsnum],$searchstring[$argsnum]) = $ARGV[$argsnum] =~ m/^([-|+]):(.*)$/  ; 
-			$tempstring  = $paintway[$argsnum] .(shift @colorpresets).":".$searchstring[$argsnum] ;
+			$tempstring  = $paintway[$argsnum] .$colorpresets[$i++].":".$searchstring[$argsnum] ;
 		}
 		($paintway[$argsnum], my $ttype, my $tfcol, my $tbcol, $searchstring[$argsnum]) = $tempstring =~ m/^([-|+])(i|u|n|l|b)([0-7])([0-8]):(.*)$/ ;  
 		my $type ; 

--- a/colorize.pl
+++ b/colorize.pl
@@ -73,9 +73,9 @@ foreach $argsnum (0 .. $argscount) {
 			about (); 
 		}
 		if ($htmlout == 1) {
-			if ($type eq 'i') {
+			if ($ttype eq 'i') {
 				$colorcode[$argsnum]="<span class=\"color_bg_".($tfcol+30)." color_fg_".($tbcol+40)."\" >";
-			} elsif ($type eq 'l') { 
+			} elsif ($ttype eq 'l') { 
 				$colorcode[$argsnum]="<span class=\"color_light_fg_".($tfcol+30)." color_light_bg_".($tbcol+40)."\" >" ;
 			} else {
 				$colorcode[$argsnum]="<span class=\"color_style_".$ttype." color_fg_".($tfcol+30)." color_bg_".($tbcol+40)."\" >";


### PR DESCRIPTION
hello,

I just realize, i have bug in detecting light/inverse detection in html output

also I realize while trying to realize what do you mean with one default bg color) that if more then 15condition is used withou colors specification, then array @colorpresets is truncated and perl is complaing:

Use of uninitialized value in concatenation (.) or string at ./colorize.pl line 60.

so also fix for this 

and tuned colors for html output, to be more readable

have also test case if you want to check it

t.
